### PR TITLE
stop forced change of seed in createCode function

### DIFF
--- a/R/shinyga_auth.R
+++ b/R/shinyga_auth.R
@@ -36,7 +36,7 @@
 #' }
 #' }
 createCode <- function(seed=NULL, num=20){
-  set.seed(seed)
+  if (!is.null(seed)) set.seed(seed)
   
   paste0(sample(c(1:9, LETTERS, letters), num, replace = T), collapse='')
 } 


### PR DESCRIPTION
In the existing code, if createCode is called without specifying seed, the seed is still changed.  The difference can be seen in the following code sample

set.seed(12321); createCode()

In the existing createCode, the results are different each time you run the above lines.  Normal user expectation would be that no function would change the seed apart from set.seed(); the above lines should always produce the same result.  The result is that any code following (and including) createCode() will not be reproducible.  The preferred option would be to remove the ability for the user to set the seed with in the function, but for compatibility the behaviour has been changed so that NULL seed values leave the existing seed unaltered, and therefore preserve reproducibility.
